### PR TITLE
feat: implement private messaging system with query interface

### DIFF
--- a/proto/profile/v1/activities_received.proto
+++ b/proto/profile/v1/activities_received.proto
@@ -11,6 +11,7 @@ enum ActivitiesType {
   ACTIVITIES_COMMENT = 2;
   ACTIVITIES_FOLLOW = 3;
   ACTIVITIES_MENTION = 4;
+  ACTIVITIES_SEND_MESSAGE = 5;
 }
 
 // ActivitiesReceived defines the structure of a Activities Received

--- a/proto/profile/v1/query.proto
+++ b/proto/profile/v1/query.proto
@@ -49,6 +49,10 @@ service Query {
   rpc IsAdmin(IsAdminRequest) returns (IsAdminResponse) {
     option (google.api.http).get = "/profile/v1/isAdmin/{address}";
   };
+
+  rpc QueryMessages(QueryMessagesRequest) returns (QueryMessagesResponse) {
+    option (google.api.http).get = "/profile/v1/messages/{receiver_addr}/{sender_addr}";
+  };
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -141,4 +145,13 @@ message IsAdminRequest {
 
 message IsAdminResponse {
   bool status = 1;
+}
+
+message QueryMessagesRequest {
+  string receiver_addr = 1;
+  string sender_addr = 2;
+}
+
+message QueryMessagesResponse {
+  repeated string tx_hashes = 1;
 }

--- a/proto/profile/v1/tx.proto
+++ b/proto/profile/v1/tx.proto
@@ -28,6 +28,8 @@ service Msg {
   rpc RemoveAdmin(MsgRemoveAdminRequest) returns (MsgRemoveAdminResponse);
 
   rpc ManageAdmin(MsgManageAdminRequest) returns (MsgManageAdminResponse);
+
+  rpc SendMessage(SendMessageRequest) returns (SendMessageResponse);
 }
 
 // MsgUpdateParams is the Msg/UpdateParams request type.
@@ -125,5 +127,16 @@ message MsgManageAdminRequest {
 }
 
 message MsgManageAdminResponse {
+  bool status = 1;
+}
+
+message SendMessageRequest {
+  option (cosmos.msg.v1.signer) = "creator";
+  string creator = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string targetAddr = 2;
+  string content = 3;
+}
+
+message SendMessageResponse {
   bool status = 1;
 }

--- a/x/profile/autocli.go
+++ b/x/profile/autocli.go
@@ -19,7 +19,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod: "QueryProfile",
 					Use:       "get [address]",
-					Short:     "Get the profile by wallet_address",
+					Short:     "Get the profile by address",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "address"},
 					},
@@ -114,6 +114,19 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Check if address is admin",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "address"},
+					},
+				},
+				{
+					RpcMethod: "QueryMessages",
+					Use:       "query-messages [receiver_addr] [sender_addr]",
+					Short:     "Query messages",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+						{
+							ProtoField: "receiver_addr",
+						},
+						{
+							ProtoField: "sender_addr",
+						},
 					},
 				},
 			},
@@ -220,6 +233,23 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 						},
 						{
 							ProtoField: "manage_json",
+						},
+					},
+				},
+				{
+					RpcMethod: "SendMessage",
+					Use:       "send-message [creator] [targetAddr] [content]",
+					Short:     "Send message",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+						{
+							ProtoField: "creator",
+							Optional:   false,
+						},
+						{
+							ProtoField: "targetAddr",
+						},
+						{
+							ProtoField: "content",
 						},
 					},
 				},

--- a/x/profile/types/keys.go
+++ b/x/profile/types/keys.go
@@ -42,6 +42,10 @@ const (
 
 	UserSearchFixedLength = 36
 	UserSearchPaddingChar = 0
+
+	ProfileMessagePrefix      = "Profile/Messages/"
+	ProfileMessageCountPrefix = "Profile/Messages/count/"
+	ProfileMaxMessagesPerPair = 20
 )
 
 var ORMModuleSchema = ormv1alpha1.ModuleSchemaDescriptor{


### PR DESCRIPTION
Add private messaging functionality that stores message txHashes on-chain while keeping encrypted content in transaction data.

Features:
- Add SendMessage RPC endpoint for sending encrypted messages between users
- Add QueryMessages RPC endpoint to retrieve message txHash list
- Store txHash of latest 20 messages per user pair
- Automatically delete oldest message when limit exceeded
- Add message notifications to activitiesReceived system

Technical details:
- Message storage: prefix + receiverAddr + "/" + senderAddr + "/" + timestamp
- Count tracking: prefix + receiverAddr + "/" + senderAddr + "/count"
- Messages retrievable via txHash query for decryption on client side

Modified:
- x/profile/keeper/keeper.go: Add message storage helper methods
- x/profile/keeper/msg_server.go: Implement SendMessage handler
- x/profile/keeper/query_server.go: Implement QueryMessages handler
- x/profile/types/keys.go: Add message-related key prefixes
- proto/profile/v1/tx.proto: Add encrypted_content field to SendMessageRequest
- proto/profile/v1/query.proto: Add QueryMessages RPC definition