### PR TITLE
feat: implement private messaging system with query interface

### DIFF
--- a/proto/profile/v1/tx.proto
+++ b/proto/profile/v1/tx.proto
@@ -133,7 +133,7 @@ message MsgManageAdminResponse {
 message SendMessageRequest {
   option (cosmos.msg.v1.signer) = "creator";
   string creator = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string targetAddr = 2;
+  string receiver = 2;
   string content = 3;
 }
 

--- a/x/profile/autocli.go
+++ b/x/profile/autocli.go
@@ -238,7 +238,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				{
 					RpcMethod: "SendMessage",
-					Use:       "send-message [creator] [targetAddr] [content]",
+					Use:       "send-message [creator] [receiver] [content]",
 					Short:     "Send message",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{
@@ -246,7 +246,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 							Optional:   false,
 						},
 						{
-							ProtoField: "targetAddr",
+							ProtoField: "receiver",
 						},
 						{
 							ProtoField: "content",


### PR DESCRIPTION
Add private messaging functionality that stores message txHashes on-chain while keeping encrypted content in transaction data.

Features:
- Add SendMessage RPC endpoint for sending encrypted messages between users
- Add QueryMessages RPC endpoint to retrieve message txHash list
- Store txHash of latest 20 messages per user pair
- Automatically delete oldest message when limit exceeded
- Add message notifications to activitiesReceived system

Technical details:
- Message storage: prefix + receiverAddr + "/" + senderAddr + "/" + timestamp
- Count tracking: prefix + receiverAddr + "/" + senderAddr + "/count"
- Messages retrievable via txHash query for decryption on client side

Modified:
- x/profile/keeper/keeper.go: Add message storage helper methods
- x/profile/keeper/msg_server.go: Implement SendMessage handler
- x/profile/keeper/query_server.go: Implement QueryMessages handler
- x/profile/types/keys.go: Add message-related key prefixes
- proto/profile/v1/tx.proto: Add encrypted_content field to SendMessageRequest
- proto/profile/v1/query.proto: Add QueryMessages RPC definition