### PR TITLE
feat: add automatic public key capture to user profiles

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -11,6 +11,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+
+	"github.com/rollchains/tlock/app/decorators"
+	profilekeeper "github.com/rollchains/tlock/x/profile/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -20,6 +23,7 @@ type HandlerOptions struct {
 
 	IBCKeeper     *keeper.Keeper
 	CircuitKeeper *circuitkeeper.Keeper
+	ProfileKeeper profilekeeper.Keeper
 
 	BypassMinFeeMsgTypes []string
 }
@@ -48,7 +52,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
-		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewSetPubKeyDecorator(options.AccountKeeper),                                  // SetPubKeyDecorator must be called before all signature verification decorators
+		decorators.NewProfilePubKeyDecorator(options.AccountKeeper, options.ProfileKeeper), // Update profile public key automatically
 		ante.NewValidateSigCountDecorator(options.AccountKeeper),
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),

--- a/app/app.go
+++ b/app/app.go
@@ -638,6 +638,7 @@ func NewChainApp(
 		logger,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		profileSubspace,
+		app.AccountKeeper, // Add AccountKeeper for public key retrieval
 	)
 
 	// Create the post Keeper
@@ -988,6 +989,7 @@ func NewChainApp(
 			},
 			IBCKeeper:     app.IBCKeeper,
 			CircuitKeeper: &app.CircuitKeeper,
+			ProfileKeeper: app.ProfileKeeper,
 		},
 	)
 	if err != nil {

--- a/proto/profile/v1/profile.proto
+++ b/proto/profile/v1/profile.proto
@@ -29,5 +29,9 @@ message Profile {
   IdVerificationStatus idVerification_status = 14;
   uint64 score = 15;
   string line_manager = 16;
+  // pub_key stores the user's public key in hex-encoded format
+  // This field is automatically populated from the account's public key
+  // when the user sends their first transaction
+  string pub_key = 17;
 }
 

--- a/x/profile/depinject.go
+++ b/x/profile/depinject.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 
@@ -45,6 +46,7 @@ type ModuleInputs struct {
 	StoreService store.KVStoreService
 	AddressCodec address.Codec
 
+	AccountKeeper  authkeeper.AccountKeeper
 	StakingKeeper  stakingkeeper.Keeper
 	SlashingKeeper slashingkeeper.Keeper
 	paramSpace     paramstypes.Subspace
@@ -60,7 +62,7 @@ type ModuleOutputs struct {
 func ProvideModule(in ModuleInputs) ModuleOutputs {
 	govAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 
-	k := keeper.NewKeeper(in.Cdc, in.storeKey, in.StoreService, log.NewLogger(os.Stderr), govAddr, in.paramSpace)
+	k := keeper.NewKeeper(in.Cdc, in.storeKey, in.StoreService, log.NewLogger(os.Stderr), govAddr, in.paramSpace, in.AccountKeeper)
 	m := NewAppModule(in.Cdc, k)
 
 	return ModuleOutputs{Module: m, Keeper: k, Out: depinject.Out{}}

--- a/x/profile/keeper/keeper.go
+++ b/x/profile/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"strings"
@@ -36,6 +37,7 @@ type Keeper struct {
 	authority     string
 	storeKey      kvtypes.StoreKey
 	paramSubspace paramtypes.Subspace
+	accountKeeper authkeeper.AccountKeeper
 }
 
 // NewKeeper creates a new Keeper instance
@@ -46,6 +48,7 @@ func NewKeeper(
 	logger log.Logger,
 	authority string,
 	paramSpace paramtypes.Subspace,
+	accountKeeper authkeeper.AccountKeeper,
 ) Keeper {
 	logger = logger.With(log.ModuleKey, "x/"+types.ModuleName)
 	if !paramSpace.HasKeyTable() {
@@ -80,6 +83,7 @@ func NewKeeper(
 		storeKey:      storeKey,
 		authority:     authority,
 		paramSubspace: paramSpace,
+		accountKeeper: accountKeeper,
 	}
 
 	schema, err := sb.Build()


### PR DESCRIPTION
Add pub_key field to Profile struct and implement automatic public key extraction from transactions using a custom AnteDecorator.

Changes:
- Add pub_key field to Profile protobuf definition
- Implement ProfilePubKeyDecorator to automatically capture user public keys from their first transaction
- Update ProfileKeeper to accept AccountKeeper dependency for public key retrieval
- Integrate ProfilePubKeyDecorator into AnteHandler chain after SetPubKeyDecorator
- Add protection logic in AddProfile to preserve pub_key set by AnteDecorator
- Configure dependency injection for AccountKeeper in profile module

Implementation Details:
- Uses reflection to extract Creator field from any message type, making it compatible with all current and future messages
- Only sets pub_key once; subsequent transactions skip update for performance
- Non-blocking design: errors in pub_key update don't fail transactions
- Defensive checks for edge cases (nil account, nil pubkey, etc.)
- CreationTime field used to determine if profile truly exists in database

Technical Approach:
The decorator is placed after SetPubKeyDecorator in the ante handler chain, ensuring the public key is already available in AccountKeeper before profile update. This centralized approach eliminates the need to add pub_key logic to every message handler.